### PR TITLE
added a second backslash to all singular backslashs

### DIFF
--- a/src/regexes.ts
+++ b/src/regexes.ts
@@ -14,51 +14,51 @@ export const regexEntries: RegexEntry[] = [
     {
         author_discord_tag: "TreeBen77#9066",
         author_website_url: "https://discord.gg/4CSc9E5uQy",
+        description: "Detect 99% of links, only clickable links",
+        limitations: "Only works with URLs with English characters",
+        regex: "(?:https?://)[a-z0-9_\\-\\.]{2,}\\.[a-z]{2,}"
+    },
+    {
+        author_discord_tag: "TreeBen77#9066",
+        author_website_url: "https://discord.gg/4CSc9E5uQy",
         description: "Detect 99% of links, including non-clickable links",
         limitations: "Only works with URLs with English characters",
-        regex: "(?:https?://)?[a-z0-9_\-\.]{2,}\.[a-z]{2,}"
+        regex: "(?:https?://)?[a-z0-9_\\-\\.]{2,}\\.[a-z]{2,}"
     },
     {
         author_discord_tag: "TreeBen77#9066",
         author_website_url: "https://discord.gg/4CSc9E5uQy",
         description: "Limit to 10 emojis in a message",
         limitations: "",
-        regex: "(?s)((<a?:[a-z_0-9]+:[0-9]+>|\p{Extended_Pictographic}).*){11,}"
+        regex: "(?s)((<a?:[a-z_0-9]+:[0-9]+>|\\p{Extended_Pictographic}).*){11,}"
     },
     {
         author_discord_tag: "TreeBen77#9066",
         author_website_url: "https://discord.gg/4CSc9E5uQy",
         description: "Detect official Discord invites",
         limitations: "",
-        regex: "(?:https?://)?(?:www\.|ptb\.|canary\.)?(?:discord(?:app)?\.(?:(?:com|gg)/invite/[a-z0-9-_]+)|discord\.gg/[a-z0-9-_]+)"
+        regex: "(?:https?://)?(?:www\\.|ptb\\.|canary\\.)?(?:discord(?:app)?\\.(?:(?:com|gg)/invite/[a-z0-9-_]+)|discord\\.gg/[a-z0-9-_]+)"
     },
     {
         author_discord_tag: "TreeBen77#9066",
         author_website_url: "https://discord.gg/4CSc9E5uQy",
         description: "Detect third party Discord invite domains",
         limitations: "There are other third party invite domains that are unknown",
-        regex: "(?:https?://)?(?:www\.)?(?:dsc\.gg|invite\.gg+|discord\.link)/[a-z0-9-_]+"
+        regex: "(?:https?://)?(?:www\\.)?(?:dsc\\.gg|invite\\.gg+|discord\\.link)/[a-z0-9-_]+"
     },
     {
         author_discord_tag: "TreeBen77#9066",
         author_website_url: "https://discord.gg/4CSc9E5uQy",
         description: "Detect Discord OAuth2 Link",
         limitations: "",
-        regex: "(?:https?://)?(?:www.)?discord\.com(?:/api)?/oauth2/authorize"
-    },
-    {
-        author_discord_tag: "TreeBen77#9066",
-        author_website_url: "https://discord.gg/4CSc9E5uQy",
-        description: "Detect all websites",
-        limitations: "",
-        regex: "(?:https?://)?\S{2,}\.\S{2,18}/?.*"
+        regex: "(?:https?://)?(?:www.)?discord\\.com(?:/api)?/oauth2/authorize"
     },
     {
         author_discord_tag: "TreeBen77#9066",
         author_website_url: "https://discord.gg/4CSc9E5uQy",
         description: "Detect messages with JUST uppercase",
         limitations: "Messages with just numbers will be caught",
-        regex: "(?-i)\A[^a-z]+\z"
+        regex: "(?-i)\\A[^a-z]+\\z"
     },
     {
         author_discord_tag: "TreeBen77#9066",
@@ -66,7 +66,7 @@ export const regexEntries: RegexEntry[] = [
         description: "Detect Zalgo",
         long_description: `3 = less false positives, more false negatives (detects some emojis)\n1 - more false postives, less false negatives (detects more emojis, accents and)`,
         limitations: "Some emojis may be blocked",
-        regex: "\p{M}{3,}"
+        regex: "\\p{M}{3,}"
     },
     {
         author_discord_tag: "TreeBen77#9066",
@@ -74,6 +74,6 @@ export const regexEntries: RegexEntry[] = [
         description: "Detect newline spam",
         long_description: "6 = max_allowed_newlines + 1",
         limitations: "",
-        regex: "(\n.*){6,}"
+        regex: "(\\n.*){6,}"
     }
 ]


### PR DESCRIPTION
I found a problem with most regexes that the backslashes dont appear due to the regex string being pasted. The regexes in the string need to backslashes (`//` instead of `/`). Hopefully I haven't done anything wrong.

Also I updated the other link regex that only blocked clickable links.